### PR TITLE
implemented Unstoppable domains

### DIFF
--- a/app/src/config/web3.tsx
+++ b/app/src/config/web3.tsx
@@ -1,6 +1,22 @@
 import { ICoreOptions } from 'web3modal';
 import { TNetworkInfo } from 'eth-hooks/models';
+import UAuthSPA from '@uauth/js'
+import * as UAuthWeb3Modal from '@uauth/web3modal'
 
+// For Testing (will be deleted soon)
+// clientID: 'd78ad08c-276a-4c70-b03d-fe53c22ab758',
+// redirectUri: 'http://localhost:3001/',
+
+const uauthOptions: UAuthWeb3Modal.IUAuthOptions = {
+  clientID: process.env.UD_CLIENT_ID!,
+  redirectUri: process.env.UD_REDIRECT_URI!,
+  scope: 'openid wallet',
+}
+
+
+
+
+console.log(uauthOptions)
 export const web3ModalConfigKeys = {
   coinbaseKey: 'custom-walletlink',
   localhostKey: 'custom-localhost',
@@ -90,6 +106,14 @@ export const getWeb3ModalConfig = async (): Promise<Partial<ICoreOptions>> => {
   } catch (e) {
     console.log('Failed to load config for web3 connector coinbase: ', e);
   }
+
+
+  providerOptions['custom-uauth'] =  {
+    display: UAuthWeb3Modal.display,
+    connector: UAuthWeb3Modal.connector,
+    package: UAuthSPA,
+    options: uauthOptions,
+  };
 
   return {
     cacheProvider: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
       "workspaces": [
         "*"
       ],
+      "dependencies": {
+        "@uauth/js": "^2.0.0",
+        "@uauth/web3modal": "^2.0.0"
+      },
       "devDependencies": {
         "lerna": "^5.1.4"
       },
@@ -81,6 +85,7 @@
         "@graphprotocol/graph-cli": "0.30.4",
         "@graphprotocol/graph-ts": "0.27.0",
         "dayjs": "^1.11.3",
+        "matchstick-as": "^0.5.0",
         "moment": "^2.29.3"
       }
     },
@@ -10317,6 +10322,34 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uauth/common": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@uauth/common/-/common-2.0.0.tgz",
+      "integrity": "sha512-wSK9MKa0db2BzhpHT4JFlLB90d4Fal4hHr78tW+1Tww0DZbZkqc9cV8zFOEA0aieoNU8W1kbWCAxTm4eJoM72w==",
+      "peerDependencies": {
+        "@unstoppabledomains/resolution": "^7.0"
+      }
+    },
+    "node_modules/@uauth/js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@uauth/js/-/js-2.0.0.tgz",
+      "integrity": "sha512-aOyFj9xfhvVfyollo9SaDlncEvrGatJka951onM7aCQyEuhwa41R27K1JJ5QqQSEbQThz/jW2GkGa9QyxzRpwA==",
+      "dependencies": {
+        "@uauth/common": "2.0.0",
+        "@unstoppabledomains/resolution": "^7.0",
+        "global": "^4.4.0",
+        "jose": "^4.5.0"
+      }
+    },
+    "node_modules/@uauth/web3modal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@uauth/web3modal/-/web3modal-2.0.0.tgz",
+      "integrity": "sha512-hM77rwsqsMz8i3wwKTzzTsm3NkCkmp7y9IaQkltDanJ1cbZ1TdHSN7fiFlCPkCTR3/H2EG/I+Fl0kKta/w0OMQ==",
+      "peerDependencies": {
+        "@uauth/js": "2.0.0",
+        "web3modal": "^1.9"
+      }
+    },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
       "dev": true,
@@ -10360,6 +10393,24 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@unstoppabledomains/resolution": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@unstoppabledomains/resolution/-/resolution-7.1.4.tgz",
+      "integrity": "sha512-GdXLpP+oRk4lLWMISo7g7gPyKoCONyLoQtYH6GVhXtyY9t+CeHJW2kZ/btcbXg0lmEO6PSr5yYOlDz4wRCq2RA==",
+      "dependencies": {
+        "@ethersproject/abi": "^5.0.1",
+        "bn.js": "^4.4.0",
+        "cross-fetch": "^3.1.4",
+        "elliptic": "^6.5.4",
+        "js-sha256": "^0.9.0",
+        "js-sha3": "^0.8.0"
+      }
+    },
+    "node_modules/@unstoppabledomains/resolution/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/@urql/core": {
       "version": "2.5.0",
@@ -14528,6 +14579,11 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
@@ -19558,10 +19614,6 @@
         "randombytes": "^2.0.0"
       }
     },
-    "node_modules/ganache-core/node_modules/dom-walk": {
-      "version": "0.1.2",
-      "dev": true
-    },
     "node_modules/ganache-core/node_modules/dotignore": {
       "version": "0.1.2",
       "dev": true,
@@ -21819,15 +21871,6 @@
         "node": "*"
       }
     },
-    "node_modules/ganache-core/node_modules/global": {
-      "version": "4.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "node_modules/ganache-core/node_modules/got": {
       "version": "9.6.0",
       "dev": true,
@@ -22949,13 +22992,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ganache-core/node_modules/min-document": {
-      "version": "2.19.0",
-      "dev": true,
-      "dependencies": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "node_modules/ganache-core/node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "dev": true,
@@ -23607,14 +23643,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/ganache-core/node_modules/process": {
-      "version": "0.11.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/ganache-core/node_modules/process-nextick-args": {
@@ -26586,6 +26614,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "node_modules/globals": {
@@ -30438,6 +30475,14 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/jose": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
+      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-cookie": {
       "version": "2.2.1",
       "license": "MIT"
@@ -32104,6 +32149,64 @@
         "remove-accents": "0.4.2"
       }
     },
+    "node_modules/matchstick-as": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/matchstick-as/-/matchstick-as-0.5.0.tgz",
+      "integrity": "sha512-4K619YDH+so129qt4RB4JCNxaFwJJYLXPc7drpG+/mIj86Cfzg6FKs/bA91cnajmS1CLHdhHl9vt6Kd6Oqvfkg==",
+      "dependencies": {
+        "@graphprotocol/graph-ts": "^0.27.0",
+        "assemblyscript": "^0.19.20",
+        "wabt": "1.0.24"
+      }
+    },
+    "node_modules/matchstick-as/node_modules/assemblyscript": {
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.23.tgz",
+      "integrity": "sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==",
+      "dependencies": {
+        "binaryen": "102.0.0-nightly.20211028",
+        "long": "^5.2.0",
+        "source-map-support": "^0.5.20"
+      },
+      "bin": {
+        "asc": "bin/asc",
+        "asinit": "bin/asinit"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/matchstick-as/node_modules/binaryen": {
+      "version": "102.0.0-nightly.20211028",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-102.0.0-nightly.20211028.tgz",
+      "integrity": "sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w==",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt"
+      }
+    },
+    "node_modules/matchstick-as/node_modules/long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+    },
+    "node_modules/matchstick-as/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/matchstick-as/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/mcl-wasm": {
       "version": "0.7.9",
       "dev": true,
@@ -33037,6 +33140,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/min-indent": {
@@ -36117,6 +36228,14 @@
       "dev": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-es6": {
@@ -40823,6 +40942,22 @@
       "version": "1.0.1",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/wabt": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.24.tgz",
+      "integrity": "sha512-8l7sIOd3i5GWfTWciPL0+ff/FK/deVK2Q6FN+MPz4vfUcD78i2M/49XJTwF6aml91uIiuXJEsLKWMB2cw/mtKg==",
+      "bin": {
+        "wasm-decompile": "bin/wasm-decompile",
+        "wasm-interp": "bin/wasm-interp",
+        "wasm-objdump": "bin/wasm-objdump",
+        "wasm-opcodecnt": "bin/wasm-opcodecnt",
+        "wasm-strip": "bin/wasm-strip",
+        "wasm-validate": "bin/wasm-validate",
+        "wasm2c": "bin/wasm2c",
+        "wasm2wat": "bin/wasm2wat",
+        "wat2wasm": "bin/wat2wasm"
+      }
     },
     "node_modules/walk-up-path": {
       "version": "1.0.0",
@@ -48459,6 +48594,29 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@uauth/common": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@uauth/common/-/common-2.0.0.tgz",
+      "integrity": "sha512-wSK9MKa0db2BzhpHT4JFlLB90d4Fal4hHr78tW+1Tww0DZbZkqc9cV8zFOEA0aieoNU8W1kbWCAxTm4eJoM72w==",
+      "requires": {}
+    },
+    "@uauth/js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@uauth/js/-/js-2.0.0.tgz",
+      "integrity": "sha512-aOyFj9xfhvVfyollo9SaDlncEvrGatJka951onM7aCQyEuhwa41R27K1JJ5QqQSEbQThz/jW2GkGa9QyxzRpwA==",
+      "requires": {
+        "@uauth/common": "2.0.0",
+        "@unstoppabledomains/resolution": "^7.0",
+        "global": "^4.4.0",
+        "jose": "^4.5.0"
+      }
+    },
+    "@uauth/web3modal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@uauth/web3modal/-/web3modal-2.0.0.tgz",
+      "integrity": "sha512-hM77rwsqsMz8i3wwKTzzTsm3NkCkmp7y9IaQkltDanJ1cbZ1TdHSN7fiFlCPkCTR3/H2EG/I+Fl0kKta/w0OMQ==",
+      "requires": {}
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "dev": true
@@ -48482,6 +48640,26 @@
     "@uniswap/v2-core": {
       "version": "1.0.1",
       "peer": true
+    },
+    "@unstoppabledomains/resolution": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@unstoppabledomains/resolution/-/resolution-7.1.4.tgz",
+      "integrity": "sha512-GdXLpP+oRk4lLWMISo7g7gPyKoCONyLoQtYH6GVhXtyY9t+CeHJW2kZ/btcbXg0lmEO6PSr5yYOlDz4wRCq2RA==",
+      "requires": {
+        "@ethersproject/abi": "^5.0.1",
+        "bn.js": "^4.4.0",
+        "cross-fetch": "^3.1.4",
+        "elliptic": "^6.5.4",
+        "js-sha256": "^0.9.0",
+        "js-sha3": "^0.8.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
     },
     "@urql/core": {
       "version": "2.5.0",
@@ -51536,6 +51714,11 @@
           "version": "2.2.0"
         }
       }
+    },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "domelementtype": {
       "version": "2.3.0"
@@ -55263,10 +55446,6 @@
             "randombytes": "^2.0.0"
           }
         },
-        "dom-walk": {
-          "version": "0.1.2",
-          "dev": true
-        },
         "dotignore": {
           "version": "0.1.2",
           "dev": true,
@@ -57191,14 +57370,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "global": {
-          "version": "4.4.0",
-          "dev": true,
-          "requires": {
-            "min-document": "^2.19.0",
-            "process": "^0.11.10"
-          }
-        },
         "got": {
           "version": "9.6.0",
           "dev": true,
@@ -57970,13 +58141,6 @@
           "dev": true,
           "optional": true
         },
-        "min-document": {
-          "version": "2.19.0",
-          "dev": true,
-          "requires": {
-            "dom-walk": "^0.1.0"
-          }
-        },
         "minimalistic-assert": {
           "version": "1.0.1",
           "dev": true
@@ -58412,10 +58576,6 @@
         },
         "private": {
           "version": "0.1.8",
-          "dev": true
-        },
-        "process": {
-          "version": "0.11.10",
           "dev": true
         },
         "process-nextick-args": {
@@ -60679,6 +60839,15 @@
         "is-glob": "^4.0.1"
       }
     },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "globals": {
       "version": "11.12.0"
     },
@@ -61755,6 +61924,7 @@
         "@graphprotocol/graph-cli": "0.30.4",
         "@graphprotocol/graph-ts": "0.27.0",
         "dayjs": "^1.11.3",
+        "matchstick-as": "^0.5.0",
         "moment": "^2.29.3"
       }
     },
@@ -63210,6 +63380,11 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "jose": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
+      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw=="
+    },
     "js-cookie": {
       "version": "2.2.1"
     },
@@ -64432,6 +64607,52 @@
         "remove-accents": "0.4.2"
       }
     },
+    "matchstick-as": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/matchstick-as/-/matchstick-as-0.5.0.tgz",
+      "integrity": "sha512-4K619YDH+so129qt4RB4JCNxaFwJJYLXPc7drpG+/mIj86Cfzg6FKs/bA91cnajmS1CLHdhHl9vt6Kd6Oqvfkg==",
+      "requires": {
+        "@graphprotocol/graph-ts": "^0.27.0",
+        "assemblyscript": "^0.19.20",
+        "wabt": "1.0.24"
+      },
+      "dependencies": {
+        "assemblyscript": {
+          "version": "0.19.23",
+          "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.23.tgz",
+          "integrity": "sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==",
+          "requires": {
+            "binaryen": "102.0.0-nightly.20211028",
+            "long": "^5.2.0",
+            "source-map-support": "^0.5.20"
+          }
+        },
+        "binaryen": {
+          "version": "102.0.0-nightly.20211028",
+          "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-102.0.0-nightly.20211028.tgz",
+          "integrity": "sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w=="
+        },
+        "long": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+          "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "mcl-wasm": {
       "version": "0.7.9",
       "dev": true
@@ -65121,6 +65342,14 @@
     },
     "mimic-fn": {
       "version": "2.1.0"
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
     },
     "min-indent": {
       "version": "1.0.1"
@@ -67205,6 +67434,11 @@
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
       "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
       "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-es6": {
       "version": "0.11.6"
@@ -70459,6 +70693,11 @@
     "vlq": {
       "version": "1.0.1",
       "peer": true
+    },
+    "wabt": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.24.tgz",
+      "integrity": "sha512-8l7sIOd3i5GWfTWciPL0+ff/FK/deVK2Q6FN+MPz4vfUcD78i2M/49XJTwF6aml91uIiuXJEsLKWMB2cw/mtKg=="
     },
     "walk-up-path": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,5 +37,9 @@
   ],
   "devDependencies": {
     "lerna": "^5.1.4"
+  },
+  "dependencies": {
+    "@uauth/js": "^2.0.0",
+    "@uauth/web3modal": "^2.0.0"
   }
 }


### PR DESCRIPTION
A basic implementation of the "Login With Unstoppable domains" in the project.

As of know the connected address is returned as expected, not sure if there is a way to get the nft domain, 
cause of `eth-hooks` being used.

But I can look into other possibilities if you need.

### Steps to test:
1. Enter the config details in `web3.tsx`
2. `npm run dev`

Screenshot of implementation:
1. On "Connect Wallet" click

<img width="1440" alt="Screenshot 2022-06-25 at 9 37 41 PM" src="https://user-images.githubusercontent.com/21285859/175781708-94f0996c-fa75-4d0d-9007-ee7d40caf389.png">

3. On "Unstoppable Domains" click
<img width="1439" alt="Screenshot 2022-06-25 at 9 40 16 PM" src="https://user-images.githubusercontent.com/21285859/175781813-824d5d61-50dc-4f05-ba48-52d938b44b4b.png">

4. After successful login
<img width="1438" alt="Screenshot 2022-06-25 at 9 37 19 PM" src="https://user-images.githubusercontent.com/21285859/175781821-3216e64c-fd95-4e28-ad9b-2c188527b80c.png">

